### PR TITLE
Fix the build error with "with-serde" feature in CH branch (on AArch64)

### DIFF
--- a/src/arm64/mod.rs
+++ b/src/arm64/mod.rs
@@ -1,6 +1,9 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "with-serde")]
+use serde_derive::{Deserialize, Serialize};
+
 // Export 4.14 bindings when the feature kvm-v4_20_0 is not specified.
 #[cfg(all(feature = "kvm-v4_14_0", not(feature = "kvm-v4_20_0")))]
 #[allow(clippy::all)]


### PR DESCRIPTION
This PR is the dependency of https://github.com/cloud-hypervisor/cloud-hypervisor/pull/1168.

Some code for supporting Serde was introduced on AArch64. But the
support was incomplete, some errors are seen while building on ARM.
This commit reverts all Serde support for AArch64. So nothing is
different even if "with-serde" feature is enabled on ARM.
This is a workaround for build before Serde is ready on ARM.

The change was verified on X86 and ARM with a testing PR 
https://github.com/michael2012z/cloud-hypervisor/pull/22.